### PR TITLE
made d_id permanent in entries

### DIFF
--- a/backend/db_tests.py
+++ b/backend/db_tests.py
@@ -198,12 +198,9 @@ def test_entry_save_new_with_diary():
 
     res = entry.collection.find_one({"title": title})
     assert res is not None
-    assert "d_id" not in res
-
-    # check all other items made it into db
-    del doc["d_id"]
     for item in doc:
         assert item in res
+        assert doc[item] == res[item]
 
     # check entry _id got into diary's entries array
     diary = Diary({"_id": D_ID})
@@ -220,14 +217,11 @@ def test_entry_save_old_with_diary():
     entry = Entry({"_id": id, "d_id": D_ID})
     entry.reload()
     assert entry["textBody"] == "This is the OG text."
-
-    entry["d_id"] = D_ID
     entry["textBody"] = "this is the NEW text"
     assert entry.save() is False  # False means updated existing
 
     res = entry.collection.find_one({"title": title})
     assert res is not None
-    assert "d_id" not in res
     assert entry["textBody"] == "this is the NEW text"
 
     # check entry _id NOT added again into diary's entries array

--- a/backend/model_mongodb.py
+++ b/backend/model_mongodb.py
@@ -54,7 +54,6 @@ class Entry(Model):
         diary = self.get_diary()                 # the filled Diary obj
         if not diary:
             return None
-        del self["d_id"]
         super(Entry, self).save()
         entry = self.find_entry_in_diary(diary)  # the entry json obj
         if not entry:                       # if new entry


### PR DESCRIPTION
Failed build due to npm compilation fail: 'XXXX' is defined but never used  no-unused-vars
I'm making a PR and merging anyway though bc I think Thomas fixed this in his PR and I don't want to make merge errors