### PR TITLE
Tags

### DIFF
--- a/backend/db_tests.py
+++ b/backend/db_tests.py
@@ -375,13 +375,15 @@ def test_add_tag_existing():
     assert entry is not None
     assert "_id" in entry
     assert len(entry["tags"]) == 0
-    assert entry.add_tag("valid tag") is True
+
+    tag_name = "valid tag"
+    assert entry.add_tag(tag_name) is True
     assert len(entry["tags"]) == 1
 
     tag_id = str(entry["tags"][0])  # actual ObjectId rn; TODO: should be a str
     tag = Tag({"_id": tag_id})
     assert tag.reload() is True
-    assert tag["title"] == "valid tag"
+    assert tag["title"] == tag_name
 
 
 def test_add_tag_new():
@@ -397,11 +399,14 @@ def test_add_tag_new():
     for tag in entry["tags"]:
         assert isinstance(tag, str)
 
-    entry.add_tag("new tag")
+    tag_name = "new tag"
+    entry.add_tag(tag_name)
     assert len(entry["tags"]) == 2
     for tag in entry["tags"]:
         assert isinstance(tag, str)
-    assert len(list(Tag.collection.find({"title": "new tag"}))) == 1
+    tag = Tag().find_by_title(tag_name)
+    assert tag is not None
+    assert "d_id" in tag
 
 
 def test_delete_tag_no_eid():

--- a/backend/db_tests.py
+++ b/backend/db_tests.py
@@ -405,11 +405,11 @@ def test_add_tag_new():
 
 
 def test_delete_tag_no_eid():
-    assert Entry().delete_tag("valid tag") is None
+    assert Entry().delete_tag("valid tag") is False
 
 
 def test_delete_tag_bad_eid():
-    assert Entry({"_id": str(ObjectId())}).delete_tag("valid tag") is None
+    assert Entry({"_id": str(ObjectId())}).delete_tag("valid tag") is False
 
 
 def test_delete_tag_dne():
@@ -422,7 +422,7 @@ def test_delete_tag_dne():
 
     tag_name = "bad tag"
     assert Tag().find_by_title(tag_name) is None
-    assert entry.delete_tag(tag_name) is None
+    assert entry.delete_tag(tag_name) is False
     assert len(entry["tags"]) == 2
 
 
@@ -436,9 +436,9 @@ def test_delete_tag():
 
     tag_name = "new tag"
     assert Tag().find_by_title(tag_name) is not None
-    assert entry.delete_tag(tag_name) is not None
+    assert entry.delete_tag(tag_name) is True
     assert len(entry["tags"]) == 1
-    assert Tag().find_by_title(tag_name) is None
+    assert Tag().find_by_title(tag_name) is not None
 
     assert entry.remove() is not None  # cleanup for testing
 

--- a/backend/db_tests.py
+++ b/backend/db_tests.py
@@ -10,11 +10,13 @@ D_ID = "5ececfbc28f47f5e4408ca45"
 
 def test_setup():
     # enter "test mode": use testing db
-    Entry.dbStr = Diary.dbStr = "tests"
+    Entry.dbStr = Diary.dbStr = Tag.dbStr = "tests"
     Entry.db = Entry.cluster[Entry.dbStr]
     Entry.collection = Entry.db["entries"]
     Diary.db = Diary.cluster[Diary.dbStr]
     Diary.collection = Diary.db["diaries"]
+    Tag.db = Tag.cluster[Tag.dbStr]
+    Tag.collection = Tag.db["tags"]
 
     assert Entry.collection.find_one({}) is None
     assert Diary.collection.find_one({"_id": ObjectId(D_ID)}) is not None
@@ -23,7 +25,7 @@ def test_setup():
 def test_entry_gets_TEST():
     entry = Entry()
     clxns = entry.db.list_collection_names()
-    expect = ["tests", "diaries", "entries"]
+    expect = ["tests", "tags", "diaries", "entries"]
     for item in clxns:
         assert item in expect
 
@@ -31,7 +33,7 @@ def test_entry_gets_TEST():
 def test_diary_gets_TEST():
     diary = Diary()
     clxns = diary.db.list_collection_names()
-    expect = ["tests", "diaries", "entries"]
+    expect = ["tests", "tags", "diaries", "entries"]
     for item in clxns:
         assert item in expect
 
@@ -341,6 +343,17 @@ def test_entry_remove_2():
     assert id not in diary["entries"]
 
 
+def test_tag_find_by_title_bad():
+    assert Tag().find_by_title("bad title") == []
+
+
+def test_tag_find_by_title():
+    tags = Tag().find_by_title("first tag")
+    assert not tags == []
+    assert len(tags) == 1
+    assert tags[0]['title'] == "first tag"
+
+
 def test_end():
     diary = Diary.collection.find_one({"_id": ObjectId(D_ID)})
     assert diary is not None
@@ -348,11 +361,13 @@ def test_end():
     assert Entry.collection.find_one({}) is None
 
     # set references back to main db
-    Entry.dbStr = Diary.dbStr = "myDiaryApp"
+    Entry.dbStr = Diary.dbStr = Tag.dbStr = "myDiaryApp"
     Entry.db = Entry.cluster[Entry.dbStr]
     Entry.collection = Entry.db["entries"]
     Diary.db = Diary.cluster[Diary.dbStr]
     Diary.collection = Diary.db["diaries"]
+    Tag.db = Tag.cluster[Tag.dbStr]
+    Tag.collection = Tag.db["tags"]
 
 
 # def test_find_all_diaries():

--- a/backend/db_tests.py
+++ b/backend/db_tests.py
@@ -366,7 +366,7 @@ def test_add_tag_bad_eid():
     assert Entry({"_id": str(ObjectId())}).add_tag("valid tag") is False
 
 
-def test_add_tag():
+def test_add_tag_existing():
     e_doc = {"title": "test_add_tag", "tags": [], "dateCreated": "TODO",
              "textBody": "nada mucho", "d_id": D_ID}
     entry = Entry(e_doc)
@@ -382,6 +382,26 @@ def test_add_tag():
     tag = Tag({"_id": tag_id})
     assert tag.reload() is True
     assert tag["title"] == "valid tag"
+
+
+def test_add_tag_new():
+    title = "test_add_tag"
+    res = Entry.collection.find({"title": title})
+    assert res is not None
+    id = str(res[0]["_id"])
+
+    entry = Entry({"_id": id})
+    entry.reload()
+    assert isinstance(entry["_id"], str)
+    assert len(entry["tags"]) == 1
+    for tag in entry["tags"]:
+        assert isinstance(tag, str)
+
+    entry.add_tag("new tag")
+    assert len(entry["tags"]) == 2
+    for tag in entry["tags"]:
+        assert isinstance(tag, str)
+    assert len(list(Tag.collection.find({"title": "new tag"}))) == 1
 
     assert entry.remove() is not None  # cleanup for testing
 

--- a/backend/db_tests.py
+++ b/backend/db_tests.py
@@ -413,6 +413,42 @@ def test_add_tag_new():
     assert "d_id" in tag
 
 
+def test_reload_tag_no_args():
+    assert Tag().reload() is False
+
+
+def test_reload_tag_bad_id():
+    assert Tag({'_id': ObjectId()}).reload() is False
+
+
+def test_reload_tag_no_title():
+    assert Tag({'d_id': D_ID}).reload() is False
+
+
+def test_reload_tag_no_did():
+    assert Tag({'title': 'valid tag'}).reload() is False
+
+
+def test_reload_tag_bad_title():
+    assert Tag({'title': 'bad tag title', 'd_id': D_ID}).reload() is False
+
+
+def test_reload_tag_bad_did():
+    assert Tag({'title': 'valid tag', 'd_id': ObjectId()}).reload() is False
+
+
+def test_reload_tag():
+    tag = Tag({"title": 'valid tag', 'd_id': D_ID})
+    assert tag.reload() is True
+    assert '_id' in tag
+    id = tag['_id']
+    assert isinstance(id, str)
+
+    tag2 = Tag({'_id': id})
+    assert tag2.reload() is True
+    assert tag == tag2
+
+
 def test_delete_tag_no_eid():
     assert Entry().delete_tag("valid tag") is False
 

--- a/backend/db_tests.py
+++ b/backend/db_tests.py
@@ -347,12 +347,16 @@ def test_entry_remove_2():
     assert id not in diary["entries"]
 
 
-def test_tag_find_by_title_bad():
-    assert Tag().find_by_title("bad title") is None
+def test_tag_find_by_title_bad_title():
+    assert Tag().find_by_title("bad title", D_ID) is None
+
+
+def test_tag_find_by_title_bad_did():
+    assert Tag().find_by_title("valid title", ObjectId()) is None
 
 
 def test_tag_find_by_title():
-    tag = Tag().find_by_title("first tag")
+    tag = Tag().find_by_title("first tag", D_ID)
     assert tag is not None
     assert tag['title'] == "first tag"
     assert isinstance(tag["_id"], str)
@@ -404,7 +408,7 @@ def test_add_tag_new():
     assert len(entry["tags"]) == 2
     for tag in entry["tags"]:
         assert isinstance(tag, str)
-    tag = Tag().find_by_title(tag_name)
+    tag = Tag().find_by_title(tag_name, entry.d_id)
     assert tag is not None
     assert "d_id" in tag
 
@@ -426,7 +430,7 @@ def test_delete_tag_dne():
     assert len(entry["tags"]) == 2
 
     tag_name = "bad tag"
-    assert Tag().find_by_title(tag_name) is None
+    assert Tag().find_by_title(tag_name, entry.d_id) is None
     assert entry.delete_tag(tag_name) is False
     assert len(entry["tags"]) == 2
 
@@ -440,10 +444,10 @@ def test_delete_tag():
     assert len(entry["tags"]) == 2
 
     tag_name = "new tag"
-    assert Tag().find_by_title(tag_name) is not None
+    assert Tag().find_by_title(tag_name, entry.d_id) is not None
     assert entry.delete_tag(tag_name) is True
     assert len(entry["tags"]) == 1
-    assert Tag().find_by_title(tag_name) is not None
+    assert Tag().find_by_title(tag_name, entry.d_id) is not None
 
     assert entry.remove() is not None  # cleanup for testing
 

--- a/backend/db_tests.py
+++ b/backend/db_tests.py
@@ -354,6 +354,34 @@ def test_tag_find_by_title():
     assert tags[0]['title'] == "first tag"
 
 
+def test_add_tag_no_eid():
+    assert Entry().add_tag("valid tag") is False
+
+
+def test_add_tag_bad_eid():
+    assert Entry({"_id": str(ObjectId())}).add_tag("valid tag") is False
+
+
+def test_add_tag():
+    e_doc = {"title": "test_add_tag", "tags": [], "dateCreated": "TODO",
+             "textBody": "nada mucho", "d_id": D_ID}
+    entry = Entry(e_doc)
+    entry.save()
+    entry.reload()
+    assert entry is not None
+    assert "_id" in entry
+    assert len(entry["tags"]) == 0
+    assert entry.add_tag("valid tag") is True
+    assert len(entry["tags"]) == 1
+
+    tag_id = str(entry["tags"][0])  # actual ObjectId rn; TODO: should be a str
+    tag = Tag({"_id": tag_id})
+    assert tag.reload() is True
+    assert tag["title"] == "valid tag"
+
+    assert entry.remove() is not None  # cleanup for testing
+
+
 def test_end():
     diary = Diary.collection.find_one({"_id": ObjectId(D_ID)})
     assert diary is not None

--- a/backend/db_tests.py
+++ b/backend/db_tests.py
@@ -443,13 +443,12 @@ def test_delete_tag():
     assert entry.reload() is True
     assert len(entry["tags"]) == 2
 
-    tag_name = "new tag"
+    tag_name = "valid tag"
     assert Tag().find_by_title(tag_name, entry.d_id) is not None
     assert entry.delete_tag(tag_name) is True
+    entry.reload()
     assert len(entry["tags"]) == 1
     assert Tag().find_by_title(tag_name, entry.d_id) is not None
-
-    assert entry.remove() is not None  # cleanup for testing
 
 
 def test_remove_tag_no_title():
@@ -466,6 +465,24 @@ def test_remove_tag_no_did():
 
 def test_remove_tag_bad_did():
     assert Tag({'title': 'valid tag', 'd_id': ObjectId()}).remove() is -1
+
+
+def test_remove_tag():
+    title = "test_add_tag"
+    res = Entry.collection.find({"title": title})
+    assert res is not None
+    entry = Entry(res[0])
+    assert entry.reload() is True
+    assert len(entry["tags"]) == 1
+
+    tag_name = "new tag"
+    tag = Tag({'title': tag_name, 'd_id': entry.d_id})
+    assert tag.remove() == 1
+    entry.reload()
+    assert len(entry["tags"]) == 0
+    assert Tag().find_by_title(tag_name, entry.d_id) is None
+
+    assert entry.remove() is not None  # cleanup for testing
 
 
 def test_end():

--- a/backend/db_tests.py
+++ b/backend/db_tests.py
@@ -413,6 +413,70 @@ def test_add_tag_new():
     assert "d_id" in tag
 
 
+def test_save_tag_no_args():
+    count = len(list(Tag.collection.find()))
+    Tag().save()
+    count2 = len(list(Tag.collection.find()))
+    assert count == count2
+
+
+def test_save_tag_bad_did():
+    count = len(list(Tag.collection.find()))
+    tag = Tag({'title': 'first tag', 'd_id': ObjectId()})
+    tag.save()
+    count2 = len(list(Tag.collection.find()))
+    assert count == count2
+
+
+def test_save_tag_old_id():
+    before = Tag({'_id': '5edc2aab2d64f19e729bff38'})  # id of first tag
+    before.reload()
+
+    count = len(list(Tag.collection.find()))
+    tag = Tag({'_id': '5edc2aab2d64f19e729bff38', 'title': 'wrong'})
+    tag.save()
+    tag.reload()
+    count2 = len(list(Tag.collection.find()))
+    assert count == count2
+    assert tag != before
+    assert tag['title'] == 'wrong'
+
+    tag['title'] = 'first tag'
+    tag.save()
+    tag.reload()
+    count2 = len(list(Tag.collection.find()))
+    assert count == count2
+    assert tag == before
+
+
+def test_save_tag_old_title_did():
+    before = Tag({'_id': '5edc2aab2d64f19e729bff38'})  # id of first tag
+    before.reload()
+
+    count = len(list(Tag.collection.find()))
+    tag = Tag({'title': 'first tag', 'd_id': D_ID})
+    tag.save()
+    count2 = len(list(Tag.collection.find()))
+    assert count == count2
+
+    tag.reload()
+    assert tag == before
+
+
+def test_save_tag_new_title():
+    count = len(list(Tag.collection.find()))
+    tag = Tag({'title': 'test_save_tag_new_title', 'd_id': D_ID})
+    tag.save()
+    count2 = len(list(Tag.collection.find()))
+    assert (count+1) == count2
+
+    tag.reload()
+    assert '_id' in tag
+    assert isinstance(tag['_id'], str)
+
+    tag.remove()  # cleanup
+
+
 def test_reload_tag_no_args():
     assert Tag().reload() is False
 

--- a/backend/db_tests.py
+++ b/backend/db_tests.py
@@ -452,6 +452,22 @@ def test_delete_tag():
     assert entry.remove() is not None  # cleanup for testing
 
 
+def test_remove_tag_no_title():
+    assert Tag({'d_id': D_ID}).remove() is None
+
+
+def test_remove_tag_bad_title():
+    assert Tag({'title': 'fake', 'd_id': D_ID}).remove() is -1
+
+
+def test_remove_tag_no_did():
+    assert Tag({'title': 'valid tag'}).remove() is None
+
+
+def test_remove_tag_bad_did():
+    assert Tag({'title': 'valid tag', 'd_id': ObjectId()}).remove() is -1
+
+
 def test_end():
     diary = Diary.collection.find_one({"_id": ObjectId(D_ID)})
     assert diary is not None

--- a/backend/db_tests.py
+++ b/backend/db_tests.py
@@ -167,7 +167,7 @@ def test_find_entry_in_diary_not_found():
 def test_find_entry_in_diary_found():
     title = "test_find_entry_in_diary_found"
     doc = {"title": title, "tags": [], "textBody": "nothing",
-           "dateCreated": "TODO"}
+           "dateCreated": "TODO", "d_id": D_ID}
     # put entry in db (to give it an _id) and then find in db
     Entry.collection.insert_one(doc)
     from_db = Entry.collection.find_one({"title": title})

--- a/backend/db_tests.py
+++ b/backend/db_tests.py
@@ -348,14 +348,14 @@ def test_entry_remove_2():
 
 
 def test_tag_find_by_title_bad():
-    assert Tag().find_by_title("bad title") == []
+    assert Tag().find_by_title("bad title") is None
 
 
 def test_tag_find_by_title():
-    tags = Tag().find_by_title("first tag")
-    assert not tags == []
-    assert len(tags) == 1
-    assert tags[0]['title'] == "first tag"
+    tag = Tag().find_by_title("first tag")
+    assert tag is not None
+    assert tag['title'] == "first tag"
+    assert isinstance(tag["_id"], str)
 
 
 def test_add_tag_no_eid():
@@ -421,7 +421,7 @@ def test_delete_tag_dne():
     assert len(entry["tags"]) == 2
 
     tag_name = "bad tag"
-    assert len(list(Tag().find_by_title(tag_name))) == 0
+    assert Tag().find_by_title(tag_name) is None
     assert entry.delete_tag(tag_name) is None
     assert len(entry["tags"]) == 2
 
@@ -435,10 +435,10 @@ def test_delete_tag():
     assert len(entry["tags"]) == 2
 
     tag_name = "new tag"
-    assert len(list(Tag().find_by_title(tag_name))) == 1
+    assert Tag().find_by_title(tag_name) is not None
     assert entry.delete_tag(tag_name) is not None
     assert len(entry["tags"]) == 1
-    assert len(list(Tag().find_by_title(tag_name))) == 0
+    assert Tag().find_by_title(tag_name) is None
 
     assert entry.remove() is not None  # cleanup for testing
 

--- a/backend/db_tests.py
+++ b/backend/db_tests.py
@@ -200,6 +200,7 @@ def test_entry_save_new_with_diary():
 
     res = entry.collection.find_one({"title": title})
     assert res is not None
+    assert isinstance(res["_id"], ObjectId)
     for item in doc:
         assert item in res
         assert doc[item] == res[item]
@@ -207,7 +208,10 @@ def test_entry_save_new_with_diary():
     # check entry _id got into diary's entries array
     diary = Diary({"_id": D_ID})
     diary.reload()
-    assert res["_id"] in diary["entries"]
+    assert isinstance(diary["_id"], str)
+    for e in diary["entries"]:
+        assert isinstance(e, str)
+    assert str(res["_id"]) in diary["entries"]
 
 
 def test_entry_save_old_with_diary():
@@ -231,7 +235,7 @@ def test_entry_save_old_with_diary():
     diary.reload()
     count = 0
     for id in diary["entries"]:
-        if (id == res["_id"]):
+        if (id == str(res["_id"])):
             count = count + 1
     assert count == 1
 

--- a/backend/db_tests.py
+++ b/backend/db_tests.py
@@ -403,6 +403,43 @@ def test_add_tag_new():
         assert isinstance(tag, str)
     assert len(list(Tag.collection.find({"title": "new tag"}))) == 1
 
+
+def test_delete_tag_no_eid():
+    assert Entry().delete_tag("valid tag") is None
+
+
+def test_delete_tag_bad_eid():
+    assert Entry({"_id": str(ObjectId())}).delete_tag("valid tag") is None
+
+
+def test_delete_tag_dne():
+    title = "test_add_tag"
+    res = Entry.collection.find({"title": title})
+    assert res is not None
+    entry = Entry(res[0])
+    assert entry.reload() is True
+    assert len(entry["tags"]) == 2
+
+    tag_name = "bad tag"
+    assert len(list(Tag().find_by_title(tag_name))) == 0
+    assert entry.delete_tag(tag_name) is None
+    assert len(entry["tags"]) == 2
+
+
+def test_delete_tag():
+    title = "test_add_tag"
+    res = Entry.collection.find({"title": title})
+    assert res is not None
+    entry = Entry(res[0])
+    assert entry.reload() is True
+    assert len(entry["tags"]) == 2
+
+    tag_name = "new tag"
+    assert len(list(Tag().find_by_title(tag_name))) == 1
+    assert entry.delete_tag(tag_name) is not None
+    assert len(entry["tags"]) == 1
+    assert len(list(Tag().find_by_title(tag_name))) == 0
+
     assert entry.remove() is not None  # cleanup for testing
 
 

--- a/backend/model_mongodb.py
+++ b/backend/model_mongodb.py
@@ -126,6 +126,17 @@ class Entry(Model):
             return True
         return False
 
+    def delete_tag(self, title):
+        if self._id and self.reload():
+            tags = Tag().find_by_title(title)
+            if len(tags) != 0:
+                tag = Tag(tags[0])
+                tag.reload()
+                id = tag["_id"]
+                self["tags"].remove(id)
+                return tag.remove()
+        return None
+
 
 class Tag(Model):
     cluster = pymongo.MongoClient(uri)

--- a/backend/model_mongodb.py
+++ b/backend/model_mongodb.py
@@ -90,7 +90,7 @@ class Entry(Model):
 
     def make_printable(self, entry):
         entry["_id"] = str(entry["_id"])
-        # entry["d_id"] = str(entry["d_id"])
+        entry["d_id"] = str(entry["d_id"])
         tags = entry["tags"]
         for i in range(len(tags)):
             tags[i] = str(tags[i])

--- a/backend/model_mongodb.py
+++ b/backend/model_mongodb.py
@@ -29,7 +29,8 @@ class Model(dict):
         if self._id:  # if in the db
             result = self.collection.find_one({"_id": ObjectId(self._id)})
             if result:
-                self.update(result)  # updates created Diary (w/ id) to full doc
+                self.update(result)  # updates created doc (w/ id) to full doc
+                # TODO: call a make_printable() function?
                 self._id = str(self._id)  # may also need to convert entry ids
                 return True
         return False
@@ -87,6 +88,16 @@ class Entry(Model):
                 if self._id == str(id):
                     return self.collection.find_one({"_id": ObjectId(self._id)})
         return None
+
+    # title is the unique tag title which should already exist in db
+    def add_tag(self, title):
+        if self._id and self.reload():
+            tags = Tag().find_by_title(title)
+            tag = tags[0]       # there should only be one bc unique title
+            self["tags"].append(tag["_id"])
+            self.save()
+            return True
+        return False
 
 
 class Tag(Model):

--- a/backend/model_mongodb.py
+++ b/backend/model_mongodb.py
@@ -115,11 +115,11 @@ class Entry(Model):
     # title is the unique tag title. If new tag, create tag
     def add_tag(self, title):
         if self._id and self.reload():
-            tag = Tag().find_by_title(title)
+            tag = Tag().find_by_title(title, self.d_id)
             # if new tag, create in db
             if tag is None:
                 Tag({"title": title, "d_id": self.d_id}).save()
-                tag = Tag().find_by_title(title)
+                tag = Tag().find_by_title(title, self.d_id)
             self["tags"].append(tag["_id"])
             self.save()
             return True
@@ -127,7 +127,7 @@ class Entry(Model):
 
     def delete_tag(self, title):
         if self._id and self.reload():
-            tag = Tag().find_by_title(title)
+            tag = Tag().find_by_title(title, self.d_id)
             if tag is not None:
                 tag.reload()
                 id = tag["_id"]
@@ -143,9 +143,9 @@ class Tag(Model):
     db = cluster[dbStr]
     collection = db["tags"]
 
-    # there should not de tags with the same title --> can use title to get
-    def find_by_title(self, title):
-        tags = list(self.collection.find({"title": title}))
+    # shouldn't be tags with same title in same diary --> can use title to get
+    def find_by_title(self, title, d_id):
+        tags = list(self.collection.find({"title": title, 'd_id': d_id}))
         if len(tags) > 0:
             tag = self.make_printable(Tag(tags[0]))
             return tag

--- a/backend/model_mongodb.py
+++ b/backend/model_mongodb.py
@@ -132,8 +132,9 @@ class Entry(Model):
                 tag.reload()
                 id = tag["_id"]
                 self["tags"].remove(id)
-                return tag.remove()
-        return None
+                return True
+                # return tag.remove() --> don't wan't to actually del from DB!
+        return False
 
 
 class Tag(Model):

--- a/backend/model_mongodb.py
+++ b/backend/model_mongodb.py
@@ -143,6 +143,13 @@ class Tag(Model):
     db = cluster[dbStr]
     collection = db["tags"]
 
+    def remove(self):
+        if self.title and self.d_id:
+            tag = self.find_by_title(self.title, self.d_id)
+            if not tag:
+                return -1
+        return None
+
     # shouldn't be tags with same title in same diary --> can use title to get
     def find_by_title(self, title, d_id):
         tags = list(self.collection.find({"title": title, 'd_id': d_id}))

--- a/backend/model_mongodb.py
+++ b/backend/model_mongodb.py
@@ -145,6 +145,16 @@ class Tag(Model):
     db = cluster[dbStr]
     collection = db["tags"]
 
+    def reload(self):
+        if self._id:
+            return super(Tag, self).reload()
+        elif self.title and self.d_id:
+            tag = self.find_by_title(self.title, self.d_id)
+            if tag:
+                self.update(tag)
+                return True
+        return False
+
     def remove(self):
         if self.title and self.d_id:
             self = self.find_by_title(self.title, self.d_id)

--- a/backend/model_mongodb.py
+++ b/backend/model_mongodb.py
@@ -112,11 +112,15 @@ class Entry(Model):
                     return self.collection.find_one({"_id": ObjectId(self._id)})
         return None
 
-    # title is the unique tag title which should already exist in db
+    # title is the unique tag title. If new tag, create tag
     def add_tag(self, title):
         if self._id and self.reload():
             tags = Tag().find_by_title(title)
-            tag = tags[0]       # there should only be one bc unique title
+            # if new tag, create in db
+            if len(tags) == 0:
+                Tag({"title": title}).save()
+                tags = Tag().find_by_title(title)
+            tag = tags[0]
             self["tags"].append(tag["_id"])
             self.save()
             return True

--- a/backend/model_mongodb.py
+++ b/backend/model_mongodb.py
@@ -145,6 +145,24 @@ class Tag(Model):
     db = cluster[dbStr]
     collection = db["tags"]
 
+    def save(self):
+        if self._id:
+            super(Tag, self).save()
+        elif self.title and self.d_id:
+            diary = self.get_diary(self.d_id)
+            if diary:
+                tag = self.find_by_title(self.title, self.d_id)
+                if tag:
+                    self['_id'] = tag['_id']
+                super(Tag, self).save()
+
+    def get_diary(self, diary):
+        if self.d_id:           # if diary id (so diary should exist)
+            diary = Diary({"_id": self.d_id})
+            res = diary.reload()
+            return (diary if res else None)
+        return None
+
     def reload(self):
         if self._id:
             return super(Tag, self).reload()
@@ -183,8 +201,10 @@ class Tag(Model):
         return None
 
     def make_printable(self, tag):
-        tag["_id"] = str(tag["_id"])
-        tag["d_id"] = str(tag["d_id"])
+        if '_id' in tag:
+            tag["_id"] = str(tag["_id"])
+        if 'd_id' in tag:
+            tag["d_id"] = str(tag["d_id"])
         return tag
 
 

--- a/backend/model_mongodb.py
+++ b/backend/model_mongodb.py
@@ -118,7 +118,7 @@ class Entry(Model):
             tag = Tag().find_by_title(title)
             # if new tag, create in db
             if tag is None:
-                Tag({"title": title}).save()
+                Tag({"title": title, "d_id": self.d_id}).save()
                 tag = Tag().find_by_title(title)
             self["tags"].append(tag["_id"])
             self.save()

--- a/backend/model_mongodb.py
+++ b/backend/model_mongodb.py
@@ -115,12 +115,11 @@ class Entry(Model):
     # title is the unique tag title. If new tag, create tag
     def add_tag(self, title):
         if self._id and self.reload():
-            tags = Tag().find_by_title(title)
+            tag = Tag().find_by_title(title)
             # if new tag, create in db
-            if len(tags) == 0:
+            if tag is None:
                 Tag({"title": title}).save()
-                tags = Tag().find_by_title(title)
-            tag = tags[0]
+                tag = Tag().find_by_title(title)
             self["tags"].append(tag["_id"])
             self.save()
             return True
@@ -128,9 +127,8 @@ class Entry(Model):
 
     def delete_tag(self, title):
         if self._id and self.reload():
-            tags = Tag().find_by_title(title)
-            if len(tags) != 0:
-                tag = Tag(tags[0])
+            tag = Tag().find_by_title(title)
+            if tag is not None:
                 tag.reload()
                 id = tag["_id"]
                 self["tags"].remove(id)
@@ -147,9 +145,10 @@ class Tag(Model):
     # there should not de tags with the same title --> can use title to get
     def find_by_title(self, title):
         tags = list(self.collection.find({"title": title}))
-        for tag in tags:
-            tag = self.make_printable(tag)
-        return tags
+        if len(tags) > 0:
+            tag = self.make_printable(Tag(tags[0]))
+            return tag
+        return None
 
     def make_printable(self, tag):
         tag["_id"] = str(tag["_id"])

--- a/backend/model_mongodb.py
+++ b/backend/model_mongodb.py
@@ -89,6 +89,20 @@ class Entry(Model):
         return None
 
 
+class Tag(Model):
+    cluster = pymongo.MongoClient(uri)
+    dbStr = "myDiaryApp"
+    db = cluster[dbStr]
+    collection = db["tags"]
+
+    # there should not de tags with the same title --> can use title to get
+    def find_by_title(self, title):
+        tags = list(self.collection.find({"title": title}))
+        for tag in tags:
+            tag["_id"] = str(tag["_id"])
+        return tags
+
+
 class Diary(Model):
     cluster = pymongo.MongoClient(uri)
     dbStr = "myDiaryApp"
@@ -106,6 +120,10 @@ class Diary(Model):
         for diary in diaries:  # change ObjectIDs to strs
             diary = self.make_printable(diary)
         return diaries
+
+    # tags is a string array of tag names
+    def find_by_at_least_one_tag(self, tags):
+        return None
 
     def make_printable(self, diary):
         diary["_id"] = str(diary["_id"])


### PR DESCRIPTION
Implemented Tags in the db code. Since tags are unique by title to each diary, you can use the standard db functions (save, reload, remove) with either the _id or the title/d_id combo. To do the latter, I included a d_id field in each tag just like I did for entries. The code is definitely not beautiful - there's a little repetition - but it's thoroughly tested. You can add/delete tags from and Entry level too, so there is the capability to add or delete a tag just from a single entry in addition to adding/deleting a tag to the whole db.